### PR TITLE
ChatGPTの不要なパラメータを削除

### DIFF
--- a/backend/app/Http/Controllers/ConversationController.php
+++ b/backend/app/Http/Controllers/ConversationController.php
@@ -23,8 +23,6 @@ class ConversationController extends Controller
                     'content' => $request->line
                 ]
             ],
-            'temperature' => 0.8,
-            'max_tokens' => 150,
         ]);
         $conversation = new Conversation();
         $conversation->line = $request->line;


### PR DESCRIPTION
'temperature' => 0.8,
'max_tokens' => 150,

これらは特に指定していないwebページも多かったので
削除します。