### PR TITLE
EC2のためにバックエンドのURLを環境変数で指定する方式に変更

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API="http://localhost"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/frontend/src/components/ConsultButton.js
+++ b/frontend/src/components/ConsultButton.js
@@ -13,7 +13,7 @@ export default function ConsultButton({ inputTextRef, typeStart }) {
     console.log(requestBody);
     try {
       axios
-        .post("http://localhost/conversation", requestBody, requestOptions)
+        .post(process.env.REACT_APP_API + "/conversation", requestBody, requestOptions)
         .then((res) => {
           console.log(res);
           typeStart(res.data.advice);

--- a/frontend/src/pages/Top.js
+++ b/frontend/src/pages/Top.js
@@ -13,7 +13,7 @@ export default function Top() {
   const inputText = useRef(null);
 
   useEffect(() => {
-    axios.get('http://localhost/sanctum/csrf-cookie', { withCredentials: true })
+    axios.get(process.env.REACT_APP_API + '/sanctum/csrf-cookie', { withCredentials: true })
   }, []);
 
   return (


### PR DESCRIPTION
URLがlocalhostのところをAWSのパブリックIPに変えると動いたので、
.envファイルで環境ごとに設定するようにしました(ローカルは.env.exampleのままhttp://localhostでOK)